### PR TITLE
Add instance_id to state so ID is usable in provisioners

### DIFF
--- a/builder/incus/step_incus_launch.go
+++ b/builder/incus/step_incus_launch.go
@@ -54,6 +54,11 @@ func (s *stepIncusLaunch) Run(ctx context.Context, state multistep.StateBag) mul
 
 	time.Sleep(time.Duration(sleep_seconds) * time.Second)
 	log.Printf("Sleeping for %d seconds...", sleep_seconds)
+	// instance_id is the generic term used so that users can have access
+	// to the instance id (through the `ID` property) inside the
+	// provisioner, used in step_provision.
+	state.Put("instance_id", name)
+	ui.Message(fmt.Sprintf("Instance Name: %s", name))
 	return multistep.ActionContinue
 }
 

--- a/builder/incus/step_incus_launch.go
+++ b/builder/incus/step_incus_launch.go
@@ -52,8 +52,8 @@ func (s *stepIncusLaunch) Run(ctx context.Context, state multistep.StateBag) mul
 	// TODO: Should we check `lxc info <container>` for "Running"?
 	// We have to do this so /tmp doesn't get cleared and lose our provisioner scripts.
 
-	time.Sleep(time.Duration(sleep_seconds) * time.Second)
 	log.Printf("Sleeping for %d seconds...", sleep_seconds)
+	time.Sleep(time.Duration(sleep_seconds) * time.Second)
 	// instance_id is the generic term used so that users can have access
 	// to the instance id (through the `ID` property) inside the
 	// provisioner, used in step_provision.


### PR DESCRIPTION
This will allow to use the `build.ID` in the provisioner step.

I have this use case: build both Docker and Incus containers and do it like:


```hcl
source "docker" "centos7" {
  image = "centos:7"
}

source "incus" "centos7" {
  image = "images:centos/7"
}

build {
  name = "test"

  sources [ "source.incus.centos7", "source.docker.centos7"]

  provisioner "ansible" {
    playbook_file = "./play.yml"
    user = "root"
    extra_arguments = [ "--extra-vars", "ansible_host=${build.ID} ansible_connection=community.general.${source.type}" ]
    ansible_env_vars = ["ANSIBLE_FORCE_COLOR=1"]
  }
}
```

this allows me to use the `ansible_host` and `ansible_connection` automatically be set for the builder used