### PR TITLE
Fix wrong documentation url

### DIFF
--- a/docs-partials/builder/incus/Config-not-required.mdx
+++ b/docs-partials/builder/incus/Config-not-required.mdx
@@ -22,7 +22,7 @@
 - `publish_properties` (map[string]string) - Pass key values to the publish
   step to be set as properties on the output image. This is most helpful to
   set the description, but can be used to set anything needed. See
-  https://stgraber.org/2016/03/30/incus-2-0-image-management-512/
+  https://stgraber.org/2016/03/30/lxd-2-0-image-management-512/
   for more properties.
 
 - `launch_config` (map[string]string) - List of key/value pairs you wish to


### PR DESCRIPTION
URL to explain `publish_properties` is wrong.

This PR is to replace the wrong one by this one : https://stgraber.org/2016/03/30/lxd-2-0-image-management-512/
