### PR TITLE
Add --project support

### DIFF
--- a/builder/incus/communicator.go
+++ b/builder/incus/communicator.go
@@ -20,6 +20,7 @@ import (
 type Communicator struct {
 	ContainerName string
 	CmdWrapper    CommandWrapper
+	Project       string
 }
 
 func (c *Communicator) Start(ctx context.Context, cmd *packersdk.RemoteCmd) error {
@@ -79,7 +80,7 @@ func (c *Communicator) Upload(dst string, r io.Reader, fi *os.FileInfo) error {
 		fileDestination = filepath.Join(c.ContainerName, dst, (*fi).Name())
 	}
 
-	cpCmd, err := c.CmdWrapper(fmt.Sprintf("incus file push - %s", fileDestination))
+	cpCmd, err := c.CmdWrapper(fmt.Sprintf("incus file push --project %s - %s", c.Project, fileDestination))
 	if err != nil {
 		return err
 	}
@@ -137,7 +138,7 @@ func (c *Communicator) DownloadDir(src string, dst string, exclude []string) err
 func (c *Communicator) Execute(commandString string) (*exec.Cmd, error) {
 	log.Printf("Executing with incus exec in container: %s %s", c.ContainerName, commandString)
 	command, err := c.CmdWrapper(
-		fmt.Sprintf("incus exec %s -- /bin/sh -c \"%s\"", c.ContainerName, commandString))
+		fmt.Sprintf("incus exec --project %s %s -- /bin/sh -c \"%s\"", c.Project, c.ContainerName, commandString))
 	if err != nil {
 		return nil, err
 	}

--- a/builder/incus/config.go
+++ b/builder/incus/config.go
@@ -36,6 +36,7 @@ type Config struct {
 	// E.G. my-base-image, ubuntu-daily:x, 08fababf6f27, ...
 	Image   string `mapstructure:"image" required:"true"`
 	Profile string `mapstructure:"profile"`
+	Project string `mapstructure:"project"`
 	// The number of seconds to sleep between launching
 	// the incus instance and provisioning it; defaults to 3 seconds.
 	InitSleep string `mapstructure:"init_sleep" required:"false"`
@@ -88,6 +89,10 @@ func (c *Config) Prepare(raws ...interface{}) error {
 
 	if c.Profile == "" {
 		c.Profile = "default"
+	}
+
+	if c.Project == "" {
+		c.Project = "default"
 	}
 
 	// Sadly we have to wait a few seconds for /tmp to be intialized and networking

--- a/builder/incus/config.hcl2spec.go
+++ b/builder/incus/config.hcl2spec.go
@@ -25,6 +25,7 @@ type FlatConfig struct {
 	CommandWrapper      *string           `mapstructure:"command_wrapper" required:"false" cty:"command_wrapper" hcl:"command_wrapper"`
 	Image               *string           `mapstructure:"image" required:"true" cty:"image" hcl:"image"`
 	Profile             *string           `mapstructure:"profile" cty:"profile" hcl:"profile"`
+	Project             *string           `mapstructure:"project" cty:"project" hcl:"project"`
 	InitSleep           *string           `mapstructure:"init_sleep" required:"false" cty:"init_sleep" hcl:"init_sleep"`
 	PublishProperties   map[string]string `mapstructure:"publish_properties" required:"false" cty:"publish_properties" hcl:"publish_properties"`
 	LaunchConfig        map[string]string `mapstructure:"launch_config" required:"false" cty:"launch_config" hcl:"launch_config"`
@@ -59,6 +60,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"command_wrapper":            &hcldec.AttrSpec{Name: "command_wrapper", Type: cty.String, Required: false},
 		"image":                      &hcldec.AttrSpec{Name: "image", Type: cty.String, Required: false},
 		"profile":                    &hcldec.AttrSpec{Name: "profile", Type: cty.String, Required: false},
+		"project":                    &hcldec.AttrSpec{Name: "project", Type: cty.String, Required: false},
 		"init_sleep":                 &hcldec.AttrSpec{Name: "init_sleep", Type: cty.String, Required: false},
 		"publish_properties":         &hcldec.AttrSpec{Name: "publish_properties", Type: cty.Map(cty.String), Required: false},
 		"launch_config":              &hcldec.AttrSpec{Name: "launch_config", Type: cty.Map(cty.String), Required: false},

--- a/builder/incus/step_incus_launch.go
+++ b/builder/incus/step_incus_launch.go
@@ -26,7 +26,7 @@ func (s *stepIncusLaunch) Run(ctx context.Context, state multistep.StateBag) mul
 	vm := fmt.Sprintf("--vm=%s", strconv.FormatBool(config.VirtualMachine))
 
 	launch_args := []string{
-		"launch", "--ephemeral=false", vm, profile, image, name,
+		"launch", "--project", config.Project, "--ephemeral=false", vm, profile, image, name,
 	}
 
 	for k, v := range config.LaunchConfig {
@@ -71,7 +71,7 @@ func (s *stepIncusLaunch) Cleanup(state multistep.StateBag) {
 	}
 
 	cleanup_args := []string{
-		"delete", "--force", config.ContainerName,
+		"delete", "--project", config.Project, "--force", config.ContainerName,
 	}
 
 	ui.Say("Unregistering and deleting deleting container...")

--- a/builder/incus/step_provision.go
+++ b/builder/incus/step_provision.go
@@ -25,6 +25,7 @@ func (s *StepProvision) Run(ctx context.Context, state multistep.StateBag) multi
 	comm := &Communicator{
 		ContainerName: config.ContainerName,
 		CmdWrapper:    wrappedCommand,
+		Project:       config.Project,
 	}
 
 	// Loads hook data from builder's state, if it has been set.

--- a/builder/incus/step_publish.go
+++ b/builder/incus/step_publish.go
@@ -29,7 +29,7 @@ func (s *stepPublish) Run(ctx context.Context, state multistep.StateBag) multist
 	name := config.ContainerName
 	stop_args := []string{
 		// We created the container with "--ephemeral=false" so we know it is safe to stop.
-		"stop", name,
+		"stop", "--project", config.Project, name,
 	}
 
 	ui.Say("Stopping container...")
@@ -46,7 +46,7 @@ func (s *stepPublish) Run(ctx context.Context, state multistep.StateBag) multist
 	}
 
 	publish_args := []string{
-		"publish", name, remote, "--alias", config.OutputImage,
+		"publish", "--project", config.Project, name, remote, "--alias", config.OutputImage,
 	}
 
 	if config.Reuse {

--- a/docs-partials/builder/incus/Config-not-required.mdx
+++ b/docs-partials/builder/incus/Config-not-required.mdx
@@ -16,6 +16,8 @@
 
 - `profile` (string) - Profile
 
+- `project` (string) - Project
+
 - `init_sleep` (string) - The number of seconds to sleep between launching
   the incus instance and provisioning it; defaults to 3 seconds.
 

--- a/docs-partials/builder/lxd/Config-not-required.mdx
+++ b/docs-partials/builder/lxd/Config-not-required.mdx
@@ -14,6 +14,8 @@
 
 - `profile` (string) - Profile
 
+- `project` (string) - Project
+
 - `init_sleep` (string) - The number of seconds to sleep between launching
   the incus instance and provisioning it; defaults to 3 seconds.
 


### PR DESCRIPTION
Add support for the `--project` option.

I tested it by building the plugin manually and installing it locally.

```bash
go build
packer plugins install --path ./packer-plugin-incus "github.com/bgaillard/incus"
```

Then I tested it using the following configuration (to make it work we have to create a `test` Incus project and a `test` profile with a Network and root device)

```hcl
packer {
  required_plugins {
    incus = {
      version = ">= 1.0.0"
      source  = "github.com/bgaillard/incus"
    }
  }
}

source "incus" "debian" {
  image = "images:debian/trixie/cloud"
  output_image = "bgaillard/etcd"
  profile = "test"
  project = "test"
  container_name = "etcd-packer"
  virtual_machine = false
}

build {
  sources = ["incus.debian"]
}
```

The output of the build is the following.

```bash
packer build etcd.pkr.hcl
incus.debian: output will be in this color.

==> incus.debian: Creating container...
==> incus.debian: Instance Name: etcd-packer
==> incus.debian: Stopping container...
==> incus.debian: Publishing container...
==> incus.debian: Created image: 02068ef3ea7f352cfae0c76dc5e68d95136f6c0eefaf33c8adadec5fd3bfcc9f
==> incus.debian: Unregistering and deleting deleting container...
Build 'incus.debian' finished after 26 seconds 823 milliseconds.

==> Wait completed after 26 seconds 823 milliseconds

==> Builds finished. The artifacts of successful builds are:
--> incus.debian: image: 02068ef3ea7f352cfae0c76dc5e68d95136f6c0eefaf33c8adadec5fd3bfcc9f
```

Here is a screenshot of this output.

<img width="788" height="308" alt="image" src="https://github.com/user-attachments/assets/bd80d8e1-5d97-492f-9c5e-4400b0ecb4fd" />

If those information are not sufficient to prove it's correctly working do not hesitate to ask for more.

Thanks for your help on the review.

Baptiste
