### PR TITLE
Allowing multiple profiles

### DIFF
--- a/.github/actions/build-and-persist-plugin-binary/action.yml
+++ b/.github/actions/build-and-persist-plugin-binary/action.yml
@@ -17,7 +17,7 @@ runs:
     shell: bash
   - run: rm ./pkg/packer_plugin_incus_${{ inputs.GOOS }}_${{ inputs.GOARCH }}
     shell: bash
-  - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+  - uses: actions/upload-artifact@v4
     with:
       name: "packer_plugin_incus_${{ inputs.GOOS }}_${{ inputs.GOARCH }}.zip"
       path: "pkg/packer_plugin_incus_${{ inputs.GOOS }}_${{ inputs.GOARCH }}.zip"

--- a/.web-docs/components/builder/incus/README.md
+++ b/.web-docs/components/builder/incus/README.md
@@ -81,7 +81,7 @@ build {
   with ssh for a remote build host. Defaults to `{{.Command}}`; i.e. no
   wrapper.
 
-- `profile` (string) - Profile
+- `profile` ([]string) - Profile
 
 - `project` (string) - Project
 

--- a/.web-docs/components/builder/incus/README.md
+++ b/.web-docs/components/builder/incus/README.md
@@ -81,7 +81,10 @@ build {
   with ssh for a remote build host. Defaults to `{{.Command}}`; i.e. no
   wrapper.
 
-- `profile` ([]string) - Profile
+- `profile` ([]string) - One or more Incus profiles to apply to the container or virtual machine.
+  Profiles define base configuration, such as devices and limits, that is
+  merged into the instance. Multiple profiles can be specified, and if none
+  are provided this defaults to the "default" profile.
 
 - `project` (string) - Project
 

--- a/builder/incus/config.go
+++ b/builder/incus/config.go
@@ -34,7 +34,11 @@ type Config struct {
 	// The source image to use when creating the build
 	// container. This can be a (local or remote) image (name or fingerprint).
 	// E.G. my-base-image, ubuntu-daily:x, 08fababf6f27, ...
-	Image   string   `mapstructure:"image" required:"true"`
+	Image string `mapstructure:"image" required:"true"`
+	// One or more Incus profiles to apply to the container or virtual machine.
+	// Profiles define base configuration, such as devices and limits, that is
+	// merged into the instance. Multiple profiles can be specified, and if none
+	// are provided this defaults to the "default" profile.
 	Profile []string `mapstructure:"profile"`
 	Project string   `mapstructure:"project"`
 	// The number of seconds to sleep between launching

--- a/builder/incus/config.go
+++ b/builder/incus/config.go
@@ -35,7 +35,7 @@ type Config struct {
 	// container. This can be a (local or remote) image (name or fingerprint).
 	// E.G. my-base-image, ubuntu-daily:x, 08fababf6f27, ...
 	Image   string `mapstructure:"image" required:"true"`
-	Profile map[string]string `mapstructure:"profile"`
+	Profile []string `mapstructure:"profile"`
 	Project string `mapstructure:"project"`
 	// The number of seconds to sleep between launching
 	// the incus instance and provisioning it; defaults to 3 seconds.
@@ -88,7 +88,7 @@ func (c *Config) Prepare(raws ...interface{}) error {
 	}
 
 	if c.Profile == [] {
-		c.Profile = ["default"]
+		c.Profile = []string{"default"}
 	}
 
 	if c.Project == "" {

--- a/builder/incus/config.go
+++ b/builder/incus/config.go
@@ -35,7 +35,7 @@ type Config struct {
 	// container. This can be a (local or remote) image (name or fingerprint).
 	// E.G. my-base-image, ubuntu-daily:x, 08fababf6f27, ...
 	Image   string `mapstructure:"image" required:"true"`
-	Profile string `mapstructure:"profile"`
+	Profile map[string]string `mapstructure:"profile"`
 	Project string `mapstructure:"project"`
 	// The number of seconds to sleep between launching
 	// the incus instance and provisioning it; defaults to 3 seconds.
@@ -87,8 +87,8 @@ func (c *Config) Prepare(raws ...interface{}) error {
 		errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("`image` is a required parameter for incus. Please specify an image by alias or fingerprint. e.g. `ubuntu-daily:x`"))
 	}
 
-	if c.Profile == "" {
-		c.Profile = "default"
+	if c.Profile == [] {
+		c.Profile = ["default"]
 	}
 
 	if c.Project == "" {

--- a/builder/incus/config.go
+++ b/builder/incus/config.go
@@ -34,9 +34,9 @@ type Config struct {
 	// The source image to use when creating the build
 	// container. This can be a (local or remote) image (name or fingerprint).
 	// E.G. my-base-image, ubuntu-daily:x, 08fababf6f27, ...
-	Image   string `mapstructure:"image" required:"true"`
+	Image   string   `mapstructure:"image" required:"true"`
 	Profile []string `mapstructure:"profile"`
-	Project string `mapstructure:"project"`
+	Project string   `mapstructure:"project"`
 	// The number of seconds to sleep between launching
 	// the incus instance and provisioning it; defaults to 3 seconds.
 	InitSleep string `mapstructure:"init_sleep" required:"false"`
@@ -87,7 +87,7 @@ func (c *Config) Prepare(raws ...interface{}) error {
 		errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("`image` is a required parameter for incus. Please specify an image by alias or fingerprint. e.g. `ubuntu-daily:x`"))
 	}
 
-	if c.Profile == [] {
+	if len(c.Profile) == 0 {
 		c.Profile = []string{"default"}
 	}
 

--- a/builder/incus/config.hcl2spec.go
+++ b/builder/incus/config.hcl2spec.go
@@ -24,7 +24,7 @@ type FlatConfig struct {
 	PublishRemoteName   *string           `mapstructure:"publish_remote_name" required:"false" cty:"publish_remote_name" hcl:"publish_remote_name"`
 	CommandWrapper      *string           `mapstructure:"command_wrapper" required:"false" cty:"command_wrapper" hcl:"command_wrapper"`
 	Image               *string           `mapstructure:"image" required:"true" cty:"image" hcl:"image"`
-	Profile             *string           `mapstructure:"profile" cty:"profile" hcl:"profile"`
+	Profile             []string          `mapstructure:"profile" cty:"profile" hcl:"profile"`
 	Project             *string           `mapstructure:"project" cty:"project" hcl:"project"`
 	InitSleep           *string           `mapstructure:"init_sleep" required:"false" cty:"init_sleep" hcl:"init_sleep"`
 	PublishProperties   map[string]string `mapstructure:"publish_properties" required:"false" cty:"publish_properties" hcl:"publish_properties"`
@@ -59,7 +59,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"publish_remote_name":        &hcldec.AttrSpec{Name: "publish_remote_name", Type: cty.String, Required: false},
 		"command_wrapper":            &hcldec.AttrSpec{Name: "command_wrapper", Type: cty.String, Required: false},
 		"image":                      &hcldec.AttrSpec{Name: "image", Type: cty.String, Required: false},
-		"profile":                    &hcldec.AttrSpec{Name: "profile", Type: cty.String, Required: false},
+		"profile":                    &hcldec.AttrSpec{Name: "profile", Type: cty.List(cty.String), Required: false},
 		"project":                    &hcldec.AttrSpec{Name: "project", Type: cty.String, Required: false},
 		"init_sleep":                 &hcldec.AttrSpec{Name: "init_sleep", Type: cty.String, Required: false},
 		"publish_properties":         &hcldec.AttrSpec{Name: "publish_properties", Type: cty.Map(cty.String), Required: false},

--- a/builder/incus/step_incus_launch.go
+++ b/builder/incus/step_incus_launch.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"log"
 	"strconv"
-	"time"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"

--- a/builder/incus/step_incus_launch.go
+++ b/builder/incus/step_incus_launch.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"strconv"
 	"time"
+	"strings"
 
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
@@ -22,7 +23,7 @@ func (s *stepIncusLaunch) Run(ctx context.Context, state multistep.StateBag) mul
 
 	name := config.ContainerName
 	image := config.Image
-	profile := fmt.Sprintf("--profile=%s", config.Profile)
+	profile := "--profile=" + strings.Join(config.Profile, " --profile=")
 	vm := fmt.Sprintf("--vm=%s", strconv.FormatBool(config.VirtualMachine))
 
 	launch_args := []string{

--- a/docs-partials/builder/incus/Config-not-required.mdx
+++ b/docs-partials/builder/incus/Config-not-required.mdx
@@ -14,7 +14,10 @@
   with ssh for a remote build host. Defaults to `{{.Command}}`; i.e. no
   wrapper.
 
-- `profile` ([]string) - Profile
+- `profile` ([]string) - One or more Incus profiles to apply to the container or virtual machine.
+  Profiles define base configuration, such as devices and limits, that is
+  merged into the instance. Multiple profiles can be specified, and if none
+  are provided this defaults to the "default" profile.
 
 - `project` (string) - Project
 

--- a/docs-partials/builder/incus/Config-not-required.mdx
+++ b/docs-partials/builder/incus/Config-not-required.mdx
@@ -14,7 +14,7 @@
   with ssh for a remote build host. Defaults to `{{.Command}}`; i.e. no
   wrapper.
 
-- `profile` (string) - Profile
+- `profile` ([]string) - Profile
 
 - `project` (string) - Project
 


### PR DESCRIPTION
Changed config struct so profile is a slice of strings, as incus allows specifying multiple profiles when generating an instance.

I also updated a deprecated workflow action item.

I ran `go generate` and `make test` as well as `make testacc`.